### PR TITLE
docs: add end-to-end system architecture Mermaid diagram

### DIFF
--- a/flow-diagrams/end-to-end-system-architecture.mmd
+++ b/flow-diagrams/end-to-end-system-architecture.mmd
@@ -1,0 +1,88 @@
+flowchart TB
+    %% External actors
+    subgraph Clients[Clients & Consumer Channels]
+        WEB[Web / Mobile Clients]
+        ADMIN[Ops / Admin Tools]
+    end
+
+    %% Edge and platform
+    subgraph Edge[Edge & Platform Services]
+        GW[Gateway Service\n(Spring Cloud Gateway)]
+        DISC[Service Discovery\n(Eureka)]
+        CFG[Config Server\n(Spring Cloud Config)]
+    end
+
+    %% Core business services
+    subgraph Services[Core Microservices]
+        AUTH[Auth Service\n(JWT Issuance & Validation)]
+        USER[User Service\n(User Profile, Roles, Validation)]
+        ACC[Account Service\n(Account Operations)]
+    end
+
+    %% Shared components
+    subgraph Shared[Shared Libraries & Contracts]
+        DOM[domains module\n(Shared Models & DTOs)]
+    end
+
+    %% Config and security assets
+    subgraph RuntimeAssets[Runtime Configuration & Security Assets]
+        REPO[configs/\nExternalized YAML Config]
+        CERTS[certificates/\nKeystores & Truststores]
+    end
+
+    %% Data stores
+    subgraph Data[Persistence Layer]
+        UDB[(User DB)]
+        ADB[(Account DB)]
+    end
+
+    %% Traffic flow
+    WEB -->|HTTPS| GW
+    ADMIN -->|HTTPS| GW
+
+    GW -->|/api/auth/**| AUTH
+    GW -->|/api/users/**| USER
+    GW -->|/api/accounts/**| ACC
+
+    %% Service discovery and config interactions
+    GW -.register/fetch.-> DISC
+    AUTH -.register/fetch.-> DISC
+    USER -.register/fetch.-> DISC
+    ACC -.register/fetch.-> DISC
+    CFG -.register/fetch.-> DISC
+
+    GW -.config refresh.-> CFG
+    AUTH -.config refresh.-> CFG
+    USER -.config refresh.-> CFG
+    ACC -.config refresh.-> CFG
+
+    CFG -->|reads centralized config| REPO
+
+    %% Security and identity propagation
+    CERTS --> GW
+    CERTS --> AUTH
+    CERTS --> USER
+    CERTS --> ACC
+
+    AUTH -->|JWT / identity claims| GW
+    GW -->|x-username, x-roles headers| USER
+    GW -->|identity context headers| ACC
+
+    %% Service internals
+    USER --> UDB
+    ACC --> ADB
+
+    %% Shared contract dependency
+    AUTH -.uses DTOs/models.-> DOM
+    USER -.uses DTOs/models.-> DOM
+    ACC -.uses DTOs/models.-> DOM
+
+    classDef infra fill:#EAF3FF,stroke:#4A78C2,color:#0B2E67;
+    classDef core fill:#EFFFF4,stroke:#2B8A57,color:#14532D;
+    classDef shared fill:#FFF8E8,stroke:#D88A1D,color:#7A4A00;
+    classDef data fill:#FCEEFF,stroke:#A855F7,color:#5B21B6;
+
+    class GW,DISC,CFG infra;
+    class AUTH,USER,ACC core;
+    class DOM,REPO,CERTS shared;
+    class UDB,ADB data;

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,101 @@ intended for developers, DevOps engineers, and reviewers onboarding to the proje
 - Security: Spring Security with header-based context propagation, TLS/mTLS between services.
 - Observability: Centralized, structured logging; consistent error payloads.
 
+## End-to-End System Architecture Diagram (Mermaid)
+
+```mermaid
+flowchart TB
+    %% External actors
+    subgraph Clients[Clients & Consumer Channels]
+        WEB[Web / Mobile Clients]
+        ADMIN[Ops / Admin Tools]
+    end
+
+    %% Edge and platform
+    subgraph Edge[Edge & Platform Services]
+        GW[Gateway Service\n(Spring Cloud Gateway)]
+        DISC[Service Discovery\n(Eureka)]
+        CFG[Config Server\n(Spring Cloud Config)]
+    end
+
+    %% Core business services
+    subgraph Services[Core Microservices]
+        AUTH[Auth Service\n(JWT Issuance & Validation)]
+        USER[User Service\n(User Profile, Roles, Validation)]
+        ACC[Account Service\n(Account Operations)]
+    end
+
+    %% Shared components
+    subgraph Shared[Shared Libraries & Contracts]
+        DOM[domains module\n(Shared Models & DTOs)]
+    end
+
+    %% Config and security assets
+    subgraph RuntimeAssets[Runtime Configuration & Security Assets]
+        REPO[configs/\nExternalized YAML Config]
+        CERTS[certificates/\nKeystores & Truststores]
+    end
+
+    %% Data stores
+    subgraph Data[Persistence Layer]
+        UDB[(User DB)]
+        ADB[(Account DB)]
+    end
+
+    %% Traffic flow
+    WEB -->|HTTPS| GW
+    ADMIN -->|HTTPS| GW
+
+    GW -->|/api/auth/**| AUTH
+    GW -->|/api/users/**| USER
+    GW -->|/api/accounts/**| ACC
+
+    %% Service discovery and config interactions
+    GW -.register/fetch.-> DISC
+    AUTH -.register/fetch.-> DISC
+    USER -.register/fetch.-> DISC
+    ACC -.register/fetch.-> DISC
+    CFG -.register/fetch.-> DISC
+
+    GW -.config refresh.-> CFG
+    AUTH -.config refresh.-> CFG
+    USER -.config refresh.-> CFG
+    ACC -.config refresh.-> CFG
+
+    CFG -->|reads centralized config| REPO
+
+    %% Security and identity propagation
+    CERTS --> GW
+    CERTS --> AUTH
+    CERTS --> USER
+    CERTS --> ACC
+
+    AUTH -->|JWT / identity claims| GW
+    GW -->|x-username, x-roles headers| USER
+    GW -->|identity context headers| ACC
+
+    %% Service internals
+    USER --> UDB
+    ACC --> ADB
+
+    %% Shared contract dependency
+    AUTH -.uses DTOs/models.-> DOM
+    USER -.uses DTOs/models.-> DOM
+    ACC -.uses DTOs/models.-> DOM
+
+    classDef infra fill:#EAF3FF,stroke:#4A78C2,color:#0B2E67;
+    classDef core fill:#EFFFF4,stroke:#2B8A57,color:#14532D;
+    classDef shared fill:#FFF8E8,stroke:#D88A1D,color:#7A4A00;
+    classDef data fill:#FCEEFF,stroke:#A855F7,color:#5B21B6;
+
+    class GW,DISC,CFG infra;
+    class AUTH,USER,ACC core;
+    class DOM,REPO,CERTS shared;
+    class UDB,ADB data;
+```
+
+The same Mermaid source is also available in `flow-diagrams/end-to-end-system-architecture.mmd` for reuse in diagram tools.
+
 ## Repository Structure
 
 - config-server: Spring Cloud Config Server that serves configuration for all services.


### PR DESCRIPTION
### Motivation

- Provide a clear, reusable visual of the system topology to help developers and operators understand routing, discovery, configuration, security, and data flows for onboarding and documentation purposes.

### Description

- Added an `End-to-End System Architecture Diagram (Mermaid)` section to `readme.md` containing a full flowchart that maps Clients, Gateway, Config Server, Service Discovery, Auth/User/Account services, shared `domains` contracts, certificates, and databases with key interaction arrows (routing, registration/discovery, config refresh, JWT/identity propagation).
- Added the same Mermaid source as a standalone reusable file at `flow-diagrams/end-to-end-system-architecture.mmd` for importing into Mermaid-compatible editors and tools.
- The diagram includes visual styling via `classDef` blocks and documents the main cross-cutting interactions (HTTPS ingress, gateway routing paths, service registration, config refresh, header propagation, and persistence links).

### Testing

- Ran `git diff --check` to validate formatting and whitespace, and it completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3de8e73588328858c8b3dcbb679a0)